### PR TITLE
Updated CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Adapters are compatible with any Chartboost Mediation SDK version within that ma
 
 All official releases can be found on this repository's [releases page](https://github.com/ChartBoost/chartboost-mediation-android-adapter-pangle/releases).
 
+### 4.6.2.0.5.0
+- This version of the adapter has been certified with Pangle SDK 6.2.0.5.
+
 ### 4.6.2.0.4.0
 - This version of the adapter has been certified with Pangle SDK 6.2.0.4.
 


### PR DESCRIPTION
Updated the CHANGELOG to include the `4.6.2.0.5.0` release.

PR: https://github.com/ChartBoost/chartboost-mediation-android-adapter-pangle/pull/83
Release: https://github.com/ChartBoost/chartboost-mediation-android-adapter-pangle/releases/tag/v4.6.2.0.5.0