### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All official releases can be found on this repository's [releases page](https://
 ### 5.6.2.0.6.0
 - This version of the adapter has been certified with Pangle SDK 6.2.0.6.
 
+### 4.6.2.0.6.0
+- This version of the adapter has been certified with Pangle SDK 6.2.0.6.
+- 
 ### 5.6.2.0.5.0
 - This version of the adapter has been certified with Pangle SDK 6.2.0.5.
 


### PR DESCRIPTION
Updates CHANGLE to include Pangle `4.6.2.0.6.0`.  Connected to https://github.com/ChartBoost/chartboost-mediation-android-adapter-pangle/pull/88